### PR TITLE
Handling primitives in content function

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -20,7 +20,10 @@ module.exports = function(lodash) {
   // Mixin functions
 
   function content(element) {
-    return lodash.get(element, 'content');
+    if (lodash.isObject(element)) {
+      return lodash.get(element, 'content');
+    }
+    return element;
   }
 
   function dataStructures(element) {

--- a/test/content-test.js
+++ b/test/content-test.js
@@ -4,19 +4,54 @@ var apiDescription = require('../lib/index');
 apiDescription(lodash);
 
 describe('Content Function', function() {
-  context('when content exists', function() {
+  context('when content exists as refract element', function() {
     var refract = {
-      element: 'category',
-      content: [
-        {
-          element: 'resource',
-          content: []
+      "element": "category",
+      "meta": {
+        "classes": [
+          "api"
+        ],
+        "title": {
+          "element": "string",
+          "meta": {},
+          "attributes": {
+            "sourceMap": [
+              {
+                "element": "sourceMap",
+                "meta": {},
+                "attributes": {},
+                "content": [
+                  [
+                    40,
+                    23
+                  ]
+                ]
+              }
+            ]
+          },
+          "content": "Swagger Petstore"
         }
-      ]
+      }
+    }
+
+    it('returns the content of the element', function() {
+      expect(lodash.chain(refract).get('meta.title', '').content().value()).to.deep.equal('Swagger Petstore');
+    });
+  });
+
+  context('when content exists as primitive value', function() {
+    var refract = {
+      "element": "category",
+      "meta": {
+        "classes": [
+          "api"
+        ],
+        "title": "Swagger Petstore"
+      }
     };
 
     it('returns the content of the element', function() {
-      expect(lodash.content(refract)).to.deep.equal(refract.content);
+      expect(lodash.chain(refract).get('meta.title', '').content().value()).to.deep.equal('Swagger Petstore');
     });
   });
 });


### PR DESCRIPTION
This enables to do `lodash.chain(refract).get('meta.title', '').content().value()` and we don't need to care if `meta.title` is refract element or primitive value.

I am not sure if I am not breaking some concept, but this should make easier life when traversing refract tree.